### PR TITLE
Add missing section headers

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -81,6 +81,18 @@ includes stubs for Python's standard library and several third-party
 packages. These are usually distributed with type checkers and do not
 require separate installation.
 
+Supported Constructs
+====================
+
+This sections lists constructs that compliant type checkers are expected
+to accept. Type stub authors can safely use these constructs.
+
+Type Stub Content
+=================
+
+This section documents best practices on what elements to include or
+leave out of type stubs.
+
 Style Guide
 ===========
 


### PR DESCRIPTION
To help structure the document and give the missing sections concrete names and better definitions.