### PR TITLE
Use the same argument names as the implementation

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -180,24 +180,10 @@ No::
 Functions and Methods
 ---------------------
 
-The bodies of functions and methods should consist of only the ellipsis
-operator ``...`` on the same line as the closing parenthesis and colon.
-Do not include docstrings.
-
-Yes::
-
-    def to_int1(x: str) -> int: ...
-    def to_int2(
-        x: str,
-    ) -> int: ...
-
-No::
-
-    def to_int1(x: str) -> int:
-        return int(x)
-    def to_int2(x: str) -> int:
-        ...
-    def to_int3(x: str) -> int: pass
+Use the same argument names as in the implementation.
+Otherwise using keyword arguments will fail. Of course, that
+does not apply to positional-only arguments, marked with a double
+underscore.
 
 Use the ellipsis operator ``...`` in place of actual default argument
 values. Use an explicit ``Optional`` annotation instead of
@@ -231,6 +217,25 @@ No::
         def bar(self: Foo) -> None: ...
         @classmethod
         def baz(cls: Type[Foo]) -> int: ...
+
+The bodies of functions and methods should consist of only the ellipsis
+operator ``...`` on the same line as the closing parenthesis and colon.
+Do not include docstrings.
+
+Yes::
+
+    def to_int1(x: str) -> int: ...
+    def to_int2(
+        x: str,
+    ) -> int: ...
+
+No::
+
+    def to_int1(x: str) -> int:
+        return int(x)
+    def to_int2(x: str) -> int:
+        ...
+    def to_int3(x: str) -> int: pass
 
 Private Definitions
 -------------------


### PR DESCRIPTION
Move paragraph about function bodies to the end of the section to have a more natural "flow" (arguments, return values, body).
