### PR TITLE
Use typeshed's CONTRIBUTING.md to start the content section.

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -93,6 +93,71 @@ Type Stub Content
 This section documents best practices on what elements to include or
 leave out of type stubs.
 
+Public Interface
+----------------
+
+Stubs should include the complete interface (classes, functions,
+constants, etc.) of the module they cover, but it is not always
+clear exactly what is part of the interface.
+
+The following should always be included:
+
+* All objects listed in the module's documentation.
+* All objects included in ``__all__`` (if present).
+
+Other objects may be included if they are being used in practice
+or if they are not prefixed with an underscore. (See the next section.)
+
+Undocumented Objects
+--------------------
+
+Undocumented objects may be included as long as they are marked with a comment
+of the form ``# undocumented``.
+
+Example::
+
+    def list2cmdline(seq: Sequence[str]) -> str: ...  # undocumented
+
+Such undocumented objects are allowed because omitting objects can confuse
+users. Users who see an error like "module X has no attribute Y" will
+not know whether the error appeared because their code had a bug or
+because the stub is wrong. Although it may also be helpful for a type
+checker to point out usage of private objects, we usually prefer false
+negatives (no errors for wrong code) over false positives (type errors
+for correct code). In addition, even for private objects a type checker
+can be helpful in pointing out that an incorrect type was used.
+
+Incomplete Stubs
+----------------
+
+Partial stubs can be useful, especially for larger packages, but they should
+follow the following guidelines:
+
+* Included functions and methods must list all arguments, but the arguments
+  can be left unannotated. Do not use ``Any`` to mark unannotated arguments
+  or return values.
+* Partial classes must include a ``__getattr__()`` method marked with an
+  ``# incomplete`` comment (see example below).
+* Partial modules (i.e. modules that are missing some or all classes,
+  functions, or attributes) must include a top-level ``__getattr__()``
+  function marked with an ``# incomplete`` comment (see example below).
+* Partial packages (i.e. packages that are missing one or more sub-modules)
+  must have a ``__init__.pyi`` stub that is marked as incomplete (see above).
+  A better alternative is to create empty stubs for all sub-modules and
+  mark them as incomplete individually.
+
+Example of a partial module with a partial class ``Foo`` and a partially
+annotated function ``bar()``::
+
+    def __getattr__(name: str) -> Any: ...  # incomplete
+
+    class Foo:
+        def __getattr__(self, name: str) -> Any:  # incomplete
+        x: int
+        y: str
+
+    def bar(x: str, y, *, z=...): ...
+
 Style Guide
 ===========
 


### PR DESCRIPTION
Starts the content section using the "What to include" and
"Incomplete stubs" sections from typeshed's contribution guidelines
(including the not-yet-merged rewording in
https://github.com/python/typeshed/pull/2861) with minimal tweaks
for the changed context.