### PR TITLE
Add a paragraph on stub-only objects and typing.type_check_only.

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -127,6 +127,23 @@ negatives (no errors for wrong code) over false positives (type errors
 for correct code). In addition, even for private objects a type checker
 can be helpful in pointing out that an incorrect type was used.
 
+Stub-Only Objects
+-----------------
+
+Definitions that do not exist at runtime may be included in stubs to aid in
+expressing types. Sometimes, it is desirable to make a stub-only class available
+to a stub's users - for example, to allow them to type the return value of a
+public method for which a library does not provided a usable runtime type. In
+this case, the class should be marked with ``typing.type_check_only``::
+
+  from typing import Protocol, type_check_only
+
+  @type_check_only
+  class Readable(Protocol):
+    def read(self) -> str: ...
+
+  def get_reader() -> Readable: ...
+
 Incomplete Stubs
 ----------------
 


### PR DESCRIPTION
Resolves https://github.com/srittau/type-stub-pep/issues/21.

Based on our recent discussions about what to include in a stub, I think a reasonable resolution here is to back off from suggesting public stub-only classes over private runtime classes, but still recommend that stub-only classes be decorated with `type_check_only` when they are intended to be public.