### PR TITLE
Fix a typo and update pytype's one sentence summary.

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -310,7 +310,7 @@ No::
 Private Definitions
 -------------------
 
-Type variables, type aliases, and other other definitions that should not
+Type variables, type aliases, and other definitions that should not
 be used outside the stub should be marked as private by prefixing them
 with an underscore.
 
@@ -413,7 +413,7 @@ Type Checkers
   Supports Python 2 and 3.
 * pyre [#pyre]_, written in OCaml and optimized for performance.
   Supports Python 3 only.
-* pytype [#pytype]_, supports type checking un-annotated code.
+* pytype [#pytype]_, checks and infers types for unannotated code.
   Supports Python 2 and 3.
 
 Development Environments


### PR DESCRIPTION
* Deletes a repeated word.
* Updates the pytype summary to more closely match the language in its README.