### PR TITLE
Add a section on `# type: ignore` and clarify a point about __getattr__.

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -87,6 +87,16 @@ Supported Constructs
 This sections lists constructs that compliant type checkers are expected
 to accept. Type stub authors can safely use these constructs.
 
+Structured comments
+-------------------
+
+Two kinds of structured comments are accepted:
+
+* A ``# type: X`` comment at the end of a line that defines a variable,
+  declaring that the variable has type ``X``.
+* A ``# type: ignore`` comment at the end of any line, which suppresses all type
+  errors in that line.
+
 Type Stub Content
 =================
 
@@ -232,6 +242,9 @@ A good stub definition::
       def __setattr__(self, name: str, value: int) -> None: ...
 
 ``__delattr__`` should not be included in stubs.
+
+Finally, even in the presence of ``__getattr__`` and ``__setattr__``, it is
+still recommended to separately define known attributes.
 
 Documentation or Implementation
 -------------------------------

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -93,7 +93,8 @@ Structured comments
 Two kinds of structured comments are accepted:
 
 * A ``# type: X`` comment at the end of a line that defines a variable,
-  declaring that the variable has type ``X``.
+  declaring that the variable has type ``X``. However, PEP 526-style [#pep526]_
+  variable annotations are preferred over type comments.
 * A ``# type: ignore`` comment at the end of any line, which suppresses all type
   errors in that line.
 


### PR DESCRIPTION
Makes two small and (hopefully) noncontroversial changes:

* `# type: ignore` is allowed on every line, as described in #7.
* `__{get,set}attr__` should not replace more specific definitions.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
