### PR TITLE
 Add "Aliases" and "Decorators" to supported constructs section.

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -116,13 +116,13 @@ generic class definitions.
 Decorators
 ----------
 
-Type stubs may only use a fixed set of decorators:
+Type stubs may only use decorators defined in the ``typing`` module, plus a
+fixed set of additional ones:
 
 * ``classmethod``
 * ``staticmethod``
 * ``property`` (including ``.setter``)
 * ``abc.abstractmethod``
-* ``typing.overload``
 * ``asyncio.coroutines.coroutine``
 
 The behavior of other decorators should instead be incorporated into the types.

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -118,12 +118,12 @@ Decorators
 
 Type stubs may only use a fixed set of decorators:
 
-  * ``classmethod``
-  * ``staticmethod``
-  * ``property`` (including ``.setter``)
-  * ``abc.abstractmethod``
-  * ``typing.overload``
-  * ``asyncio.coroutines.coroutine``
+* ``classmethod``
+* ``staticmethod``
+* ``property`` (including ``.setter``)
+* ``abc.abstractmethod``
+* ``typing.overload``
+* ``asyncio.coroutines.coroutine``
 
 The behavior of other decorators should instead be incorporated into the types.
 For example, for the following function::

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -87,6 +87,57 @@ Supported Constructs
 This sections lists constructs that compliant type checkers are expected
 to accept. Type stub authors can safely use these constructs.
 
+Aliases
+-------
+
+Type checkers should accept module-level and class-level aliases, e.g.::
+
+  IntList = List[int]
+
+  class C:
+    def f(self) -> int: ...
+    g = f
+
+An alias to a type may contain type variables, in which case all type variables
+must be substituted when the alias is used::
+
+  _K = TypeVar("_K")
+  _V = TypeVar("_V")
+  _MyMap = Dict[str, Dict[_K, _V]]
+
+  # either concrete types or other type variables can be substituted
+  def f(x: _MyMap[str, _V]) -> _V: ...
+  # explicitly substitute in Any rather than using a bare alias
+  def f(x: _MyMap[Any, Any]) -> Any: ...
+
+Otherwise, type variables in aliases follow the same rules as type variables in
+generic class definitions.
+
+Decorators
+----------
+
+Type stubs may only use a fixed set of decorators:
+
+  * ``classmethod``
+  * ``staticmethod``
+  * ``property`` (including ``.setter``)
+  * ``abc.abstractmethod``
+  * ``typing.overload``
+  * ``asyncio.coroutines.coroutine``
+
+The behavior of other decorators should instead be incorporated into the types.
+For example, for the following function::
+
+  import contextlib
+  @contextlib.contextmanager
+  def f():
+    yield 42
+
+the stub definition should be::
+
+  from typing import ContextManager
+  def f() -> ContextManager[int]: ...
+
 Type Stub Content
 =================
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -92,7 +92,7 @@ Aliases
 
 Type checkers should accept module-level and class-level aliases, e.g.::
 
-  IntList = List[int]
+  _IntList = List[int]
 
   class C:
     def f(self) -> int: ...
@@ -108,7 +108,7 @@ must be substituted when the alias is used::
   # either concrete types or other type variables can be substituted
   def f(x: _MyMap[str, _V]) -> _V: ...
   # explicitly substitute in Any rather than using a bare alias
-  def f(x: _MyMap[Any, Any]) -> Any: ...
+  def g(x: _MyMap[Any, Any]) -> Any: ...
 
 Otherwise, type variables in aliases follow the same rules as type variables in
 generic class definitions.


### PR DESCRIPTION
I'm not entirely clear on how type aliases containing type variables work, so I took my best guess at it.