### PR TITLE
Add a Supported Constructs subsection on `__all__`.

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -732,6 +732,22 @@ Maybe::
 Avoid ``Union`` return types, since they require ``isinstance()`` checks.
 Use ``Any`` if necessary.
 
+``__all___``
+------------
+
+Only define ``__all__`` when necessary to control import behavior, and use a
+list literal.
+
+Yes::
+
+  __all__ = ["foo", "bar"]
+
+No::
+
+  __all__ = ("foo", "bar")
+
+  __all__ = {"foo", "bar"}
+
 Existing Tools
 ==============
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -274,7 +274,7 @@ the stub definition should be::
   from typing import ContextManager
   def f() -> ContextManager[int]: ...
 
-Structured comments
+Structured Comments
 -------------------
 
 Two kinds of structured comments are accepted:
@@ -284,6 +284,21 @@ Two kinds of structured comments are accepted:
   variable annotations are preferred over type comments.
 * A ``# type: ignore`` comment at the end of any line, which suppresses all type
   errors in that line.
+
+``__all__``
+-----------
+
+Stubs support customizing star import semantics by defining a module-level
+variable called ``__all__``. ``__all__`` should be a list of strings. By
+default, ``from foo import *`` imports all names in ``foo`` that do not begin
+with an underscore. When ``__all__`` is defined, only those names specified in
+``__all__`` are imported::
+
+  __all__ = ['public_attr', '_private_looking_public_attr']
+
+  public_attr: int
+  _private_looking_public_attr: int
+  private_attr: int
 
 Type Stub Content
 =================

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -289,10 +289,10 @@ Two kinds of structured comments are accepted:
 -----------
 
 Stubs support customizing star import semantics by defining a module-level
-variable called ``__all__``. ``__all__`` should be a list of strings. By
-default, ``from foo import *`` imports all names in ``foo`` that do not begin
-with an underscore. When ``__all__`` is defined, only those names specified in
-``__all__`` are imported::
+variable called ``__all__``. ``__all__`` should be a list, set, or tuple of
+strings. By default, ``from foo import *`` imports all names in ``foo`` that do
+not begin with an underscore. When ``__all__`` is defined, only those names
+specified in ``__all__`` are imported::
 
   __all__ = ['public_attr', '_private_looking_public_attr']
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -289,9 +289,9 @@ Two kinds of structured comments are accepted:
 -----------
 
 Stubs support customizing star import semantics by defining a module-level
-variable called ``__all__``. ``__all__`` should be a list, set, or tuple of
-strings. By default, ``from foo import *`` imports all names in ``foo`` that do
-not begin with an underscore. When ``__all__`` is defined, only those names
+variable called ``__all__``. ``__all__`` should be a list, set, or tuple literal
+of strings. By default, ``from foo import *`` imports all names in ``foo`` that
+do not begin with an underscore. When ``__all__`` is defined, only those names
 specified in ``__all__`` are imported::
 
   __all__ = ['public_attr', '_private_looking_public_attr']


### PR DESCRIPTION
Resolves https://github.com/srittau/type-stub-pep/issues/20.