### PR TITLE
"Supported Constructs" section enums

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -354,6 +354,46 @@ specified in ``__all__`` are imported::
   public_attr: int
   _private_looking_public_attr: int
   private_attr: int
+  
+Enums
+-----
+
+Enum classes are supported in stubs, regardless of the Python version targeted by
+the stubs.
+
+Enum members may be specified just like other forms of assignments, for example as
+``x: int``, ``x = 0``, or ``x = ...``.  The first syntax is preferred because it
+allows type checkers to correctly type the ``.value`` attribute of enum members,
+without providing unnecessary information like the runtime value of the enum member.
+
+Additional properties on enum members should be specified with ``@property``, so they
+do not get interpreted by type checkers as enum members.
+
+Yes::
+
+    from enum import Enum
+    
+    class Color(Enum):
+        RED: int
+        BLUE: int
+        @property
+        def rgb_value(self) -> int: ...
+
+    class Color(Enum):
+        # discouraged; type checkers will not understand that Color.RED.value is an int
+        RED = ...
+        BLUE = ...
+        @property
+        def rgb_value(self) -> int: ...
+
+No::
+
+    from enum import Enum
+    
+    class Color(Enum):
+        RED: int
+        BLUE: int
+        rgb_value: int  # no way for type checkers to know that this is not an enum meber
 
 Type Stub Content
 =================


### PR DESCRIPTION
One issue we didn't discuss is the interaction between enums and Python versions. Enums have only been in the stdlib since Python 3.4 (PEP 435), but there is a backport for Python 2 which also has stubs in typeshed. Typeshed already uses enums in Python 2-only stubs (third_party/2/cryptography/hazmat/primitives/serialization.pyi). Therefore, I think we should expect type checkers to support enums in stubs regardless of the Python version targeted.

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
