### PR TITLE
Rework the syntax section

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -54,23 +54,26 @@ this PEP should be documented.
 Syntax
 ======
 
-Type stubs are syntactically valid Python files with a ``.pyi`` suffix.
-They should be valid according to the latest Python version six months
-after release at the latest, but can start to use features from that
-release from the release date on.
-Type stubs authors are encouraged to use the latest available syntax
-features in stubs, even if the type information in the stub is targeted
-to an older Python version.
+Type stubs are syntactically valid Python 3.7 files with a ``.pyi`` suffix.
+The Python syntax used for type stubs is independent from the Python
+versions supported by the implementation, and from the Python version the type
+checker runs under (if any). Therefore, type stub authors should use the
+latest available syntax features in stubs (up to Python 3.7), even if the
+implementation supports older, pre-3.7 Python versions.
+Type checker authors are encouraged to support syntax features from
+post-3.7 Python versions, although type stub authors should not use such
+features if they wish to maintain compatibility with all type checkers.
 
-Type checkers are expected to support the syntax of the latest released Python
-version.
+For example, Python 3.7 added the ``async`` keyword (see PEP 492 [#pep492]_).
+Stub authors should use it to mark coroutines, even if the implementation
+still uses the ``@coroutine`` decorator. On the other hand, type stubs should
+not use the positional-only syntax from PEP 570 [#pep570]_, introduced in
+Python 3.8, although type checker authors are encouraged to support it.
 
-For example, Python 3.7, which reserved ``async`` and ``await``
-as keywords (see [#pep492]_), was released on June 27nd, 2018. Type
-checkers should support them by that date and type stubs could start
-using ``async`` to mark function definitions. Additionally, type stubs
-should stop using the new keyword as an attribute or function name before
-December 27nd, 2018.
+Starting with Python 3.8, the ast_ module from the standard library supports
+all syntax features required by this PEP. Older Python versions can use the
+typed_ast_ package, which also supports Python 3.7 syntax and ``# type``
+comments.
 
 Distribution
 ============
@@ -888,6 +891,7 @@ PEPs
 .. [#pep526] PEP 526 -- Syntax for Variable Annotations, Gonzalez et al. (https://www.python.org/dev/peps/pep-0526)
 .. [#pep544] PEP 544 -- Protocols: Structural Subtyping, Levkivskyi et al. (https://www.python.org/dev/peps/pep-0544)
 .. [#pep561] PEP 561 -- Distributing and Packaging Type Information, Smith (https://www.python.org/dev/peps/pep-0561)
+.. [#pep570] PEP 570 -- Python Positional-Only Parameters, Hastings et al. (https://www.python.org/dev/peps/pep-0570)
 .. [#pep3107] PEP 3107 -- Function Annotations, Winter and Lownds (https://www.python.org/dev/peps/pep-3107)
 
 Type Checkers
@@ -905,6 +909,8 @@ Other Resources
 .. [#flake8] Flake8: Your Tool For Style Guide Enforcement (http://flake8.pycqa.org/)
 .. [#flake8-pyi] flake8-pyi (https://github.com/ambv/flake8-pyi)
 .. [#typeshed] typeshed -- Collection of library stubs for Python, with static types (https://github.com/python/typeshed)
+.. [#ast] ast -- Abstract Syntax Trees, Python standard library module (https://docs.python.org/3/library/ast.html)
+.. [#typed_ast] typed_ast -- Fork of CPython's ast module (https://pypi.org/project/typed-ast/)
 
 Copyright
 =========


### PR DESCRIPTION
Type checkers are now required to support syntax up to Python 3.7 for stubs

Closes #53
