### PR TITLE
Describe PEP as living documentation

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -93,8 +93,8 @@ require separate installation.
 Supported Constructs
 ====================
 
-This sections lists constructs that compliant type checkers are expected
-to accept. Type stub authors can safely use these constructs. If a
+This sections lists constructs that type checkers will accept in type stubs.
+Type stub authors can safely use these constructs. If a
 construct is marked as "unspecified", type checkers may handle it
 as they best see fit or report an error. Linters should usually
 flag those constructs. Type stub authors should avoid using them to

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -35,21 +35,24 @@ stubs serve multiple purposes:
   members.
 
 This PEP aims to give guidance to both authors of type stubs and developers
-of type checkers. It describes the contents of compliant type stubs,
-suggests a style guide for them, and lists constructs that compliant type
+of type checkers. It describes the constructs that can be used safely in type stubs,
+suggests a style guide for them, and lists constructs that type
 checkers are expected to support.
 
-A type stub is considered to be compliant if it only uses constructs decribed
-in this PEP. Type stub authors can elect to use additional constructs, but
+Type stubs that only use constructs described in this PEP should work with
+all type checkers that also follow this PEP.
+Type stub authors can elect to use additional constructs, but
 must be prepared that some type checkers will not parse them as expected.
 
-A type checker is considered to be compliant if
-it accepts all compliant type stubs. This means it
-will parse a compliant type stub without error and does not interpret any
-construct in a contradictory manner. A compliant type checker is not
-required to interpret all standard constructs, and additionally a type checker
-can support extra constructs not described in this PEP. All deviations from
-this PEP should be documented.
+A type checker that conforms to this PEP will parse a type stub only using
+constructs described here without error and does not interpret any
+construct in a contradictory manner. Type checkers are not
+required to implement checks for all these constructs, though, but
+can elect to ignore unsupported ones. Additionally a type checker
+can support additional constructs not described in this PEP.
+
+This PEP is intended as a living document and will be updated as new
+features are supported or best practices evolve.
 
 Syntax
 ======

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -44,10 +44,10 @@ all type checkers that also follow this PEP.
 Type stub authors can elect to use additional constructs, but
 must be prepared that some type checkers will not parse them as expected.
 
-A type checker that conforms to this PEP will parse a type stub only using
-constructs described here without error and does not interpret any
-construct in a contradictory manner. Type checkers are not
-required to implement checks for all these constructs, though, but
+A type checker that conforms to this PEP will parse a type stub that only uses
+constructs described here without error and will not interpret any
+construct in a contradictory manner. However, type checkers are not
+required to implement checks for all these constructs, and
 can elect to ignore unsupported ones. Additionally a type checker
 can support additional constructs not described in this PEP.
 


### PR DESCRIPTION
* Say that this PEP will evolve with time.
* Remove "compliance" language, as this is an informational PEP.
  Also, if a stub or type checker would like to call itself
  "compliant" with this PEP, we would need to introduce some kind
  of versioning.
* Remove requirements that deviations must be documented.
* Try to clarify what it means that a type checker to "interpret"
  a construct.
