### PR TITLE
Fix typos and improve flow.

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -238,7 +238,7 @@ argument of the ``__init__`` method::
 
 The class must match the class in which it is declared. Using other classes,
 including sub or super classes, will not work. In addition, the ``self``
-annotation can not contain the type variable itself.
+annotation cannot contain the type variable itself.
 
 Functions and Methods
 ---------------------

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -130,21 +130,19 @@ Imports
 -------
 
 Type stubs distinguish between imports that are re-exported and those
-that are only used internally. Imports are only re-exported if they
-use one of these forms:[#pep484]_
+that are only used internally. Imports are re-exported if they use one of these
+forms:[#pep484]_
 
 * ``import X as X``
 * ``from Y import X as X``
 * ``from Y import *``
 
-Stub authors can use ``import foo as foo`` to re-export an import using
-the same name::
+Here are some examples of imports that make names available for internal use in
+a stub but do not re-export them::
 
-    from foo import func as func  # "func" is re-exported
-    from foo import Cls as OtherCls  # neither name is exported
-    from foo import baz  # not exported
-    import bar as bar  # "bar" is re-exported
-    import baz  # not exported
+    import X
+    from Y import X
+    from Y import X as OtherX
 
 Type aliases can be used to re-export an import under a different name::
 
@@ -239,8 +237,8 @@ argument of the ``__init__`` method::
         def __init__(self, type: str) -> None: ...
 
 The class must match the class in which it is declared. Using other classes,
-including sub or super classes will not work. In addition, the ``self``
-annotation can not contain type variable itself.
+including sub or super classes, will not work. In addition, the ``self``
+annotation can not contain the type variable itself.
 
 Functions and Methods
 ---------------------
@@ -258,7 +256,7 @@ PEP 570 [#pep570]_ style positional-only parameters are currently not
 supported.
 
 If an argument is unannotated, its type is assumed to be ``Any``. The type of
-an argument where annotation and the type of the default argument disagree
+an argument where the annotation and the type of the default argument disagree
 is unspecified. As an exception, the ellipsis literal can stand in for any
 type::
 
@@ -391,7 +389,6 @@ support the tuple-based version check syntax::
 
     if sys.version_info < (3,):
         # This is only necessary when a feature has no Python 3 equivalent.
-        # "<= (2, 7)" does not work because e.g. (2, 7, 1) > (2, 7).
 
 Type stubs should avoid checking against ``sys.version_info.major``
 directly and should not use comparison operators other than ``<`` and ``>=``.
@@ -403,6 +400,9 @@ No::
 
     if sys.version_info[0] >= 3:
         # This is also the same.
+
+    if sys.version_info <= (2, 7):
+        # This does not work because e.g. (2, 7, 1) > (2, 7).
 
 Some type stubs also may need to specify type hints for different platforms.
 Platform checks must be equality comparisons between ``sys.platform`` and the name

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -902,7 +902,7 @@ No::
 Types
 -----
 
-Generally, use ``Any`` when a type can not be expressed appropriately
+Generally, use ``Any`` when a type cannot be expressed appropriately
 with the current type system or using the correct type is unergonomic.
 
 Use ``float`` instead of ``Union[int, float]``.


### PR DESCRIPTION
* Add some missing words and punctuation.
* Rework the imports example a bit to remove redundancy.
* Make using <= in a version check a standalone bad example rather than
  hiding it in a comment in the good examples section.
