### PR TITLE
Tweak language around docstrings and other non-empty method bodies.

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -288,10 +288,9 @@ But::
 
 An unannotated return type is assumed to be ``Any``.
 
-Using a function or method body other than the ellipsis literal is
-unspecified. Stub authors should avoid any other body, including
-ones consisting only of ``pass`` or a docstring if they want to ensure
-compatibility with all type checkers::
+Using a function or method body other than the ellipsis literal is currently
+unspecified. Stub authors may experiment with other bodies, but it is up to
+individual type checkers how to interpret them.
 
     def foo(): ...  # compatible
     def bar(): pass  # behavior undefined
@@ -769,8 +768,6 @@ No::
 Classes
 -------
 
-Do not include docstrings in class bodies.
-
 Classes without bodies should use the ellipsis literal ``...`` in place
 of the body on the same line as the class definition.
 
@@ -844,7 +841,6 @@ No::
 
 The bodies of functions and methods should consist of only the ellipsis
 literal ``...`` on the same line as the closing parenthesis and colon.
-Do not include docstrings.
 
 Yes::
 


### PR DESCRIPTION
For https://github.com/srittau/type-stub-pep/issues/88.