### PR TITLE
Some type checkers handle unannotated argument different from 'Any'

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -257,7 +257,7 @@ PEP 570 [#pep570]_ style positional-only parameters are currently not
 supported.
 
 If an argument or return type is unannotated, per PEP 484 [#pep484]_ its
-type is assumed to be ``Any``. Note that it is preferred to leave unknown
+type is assumed to be ``Any``. It is preferred to leave unknown
 types unannotated rather than explicitly marking them as ``Any``, as some
 type checkers can optionally warn about unannotated arguments.
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -257,8 +257,9 @@ PEP 570 [#pep570]_ style positional-only parameters are currently not
 supported.
 
 If an argument or return type is unannotated, per PEP 484 [#pep484]_ its
-type is assumed to be ``Any``. Some type checkers can optionally treat
-unannotated arguments or return types more strictly.
+type is assumed to be ``Any``. Note that it is preferred to leave unknown
+types unannotated rather than explicitly marking them as ``Any``, as some
+type checkers can optionally warn about unannotated arguments.
 
 The type of
 an argument where the annotation and the type of the default argument disagree

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -256,7 +256,11 @@ with two underscores), it can be used as a keyword argument [#pep484]_::
 PEP 570 [#pep570]_ style positional-only parameters are currently not
 supported.
 
-If an argument is unannotated, its type is assumed to be ``Any``. The type of
+If an argument or return type is unannotated, per PEP 484 [#pep484]_ its
+type is assumed to be ``Any``. Some type checkers can optionally treat
+unannotated arguments or return types more strictly.
+
+The type of
 an argument where the annotation and the type of the default argument disagree
 is unspecified. As an exception, the ellipsis literal can stand in for any
 type::
@@ -285,8 +289,6 @@ But::
         def do_things(self: _T): ...  # self has type _T
         @classmethod
         def create_it(cls: _T): ...  # cls has type _T
-
-An unannotated return type is assumed to be ``Any``.
 
 Using a function or method body other than the ellipsis literal is currently
 unspecified. Stub authors may experiment with other bodies, but it is up to
@@ -559,8 +561,8 @@ Partial stubs can be useful, especially for larger packages, but they should
 follow the following guidelines:
 
 * Included functions and methods should list all arguments, but the arguments
-  can be left unannotated. Do not use ``Any`` to mark unannotated arguments
-  or return values.
+  can be left unannotated.
+* Do not use ``Any`` to mark unannotated arguments or return values.
 * Partial classes should include a ``__getattr__()`` method marked with an
   ``# incomplete`` comment (see example below).
 * Partial modules (i.e. modules that are missing some or all classes,


### PR DESCRIPTION
Closes: #95

<!--

Please include the PEP number in the pull request title, example:

PEP NNN: Summary of the changes made

In addition, please sign the CLA.

For more information, please read our Contributing Guidelines (CONTRIBUTING.rst)

-->
